### PR TITLE
require ghc 8.0+, fixes #1

### DIFF
--- a/acme-circular-containers.cabal
+++ b/acme-circular-containers.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 980e3276399f08482c32210d12f178e2aafcdad96b4dbbe8519a8b772547d126
+-- hash: 9edba3791171ba008f4342d72e726bef57e26cb4e89efd1fb3b50be4dbf27248
 
 name:           acme-circular-containers
 version:        0.1.0.0
@@ -35,7 +35,7 @@ library
       src
   ghc-options: -W -Wall
   build-depends:
-      base >=4.8 && <5
+      base >=4.9 && <5
     , containers >=0.5.8
     , graph-wrapper >=0.2.6.0
   default-language: Haskell2010
@@ -48,7 +48,7 @@ test-suite doctests
   hs-source-dirs:
       tests
   build-depends:
-      base >=4.8 && <5
+      base >=4.9 && <5
     , containers >=0.5.8
     , doctest
     , doctest-discover

--- a/package.yaml
+++ b/package.yaml
@@ -12,7 +12,7 @@ extra-source-files:
 - README.md
 
 dependencies:
-  - base >= 4.8 && < 5
+  - base >= 4.9 && < 5
   - containers >= 0.5.8
   - graph-wrapper >= 0.2.6.0
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,3 @@
-resolver: lts-13.3
+resolver: lts-17.8
 packages:
 - .
-extra-deps:
-- graph-wrapper-0.2.6.0


### PR DESCRIPTION
#2 already fixed #1, but this fix is better. In #2, I did not understand why Seq.Empty was not in scope, so I incorrectly bumped my lower bound on the containers package. But the problem is that even in the most recent version of the containers package, Seq.Empty is not exported unless the ghc version is recent enough to support pattern synonyms.